### PR TITLE
Make activesupport a development dependency

### DIFF
--- a/sys-memory.gemspec
+++ b/sys-memory.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   spec.extra_rdoc_files = Dir['*.rdoc']
 
   spec.add_dependency('ffi', "~> 1.1")
-  spec.add_dependency('activesupport', "~> 6.0")
+  spec.add_development_dependency('activesupport', "~> 6.0")
   spec.add_development_dependency('rspec', "~> 3.9")
   spec.add_development_dependency('rake', "~> 13.0")
 


### PR DESCRIPTION
I don't think activesupport needs to be a regular dependency. Assuming github actions pass, I'll merge this.