### PR TITLE
Add FreeBSD to github action matrix.

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -46,6 +46,7 @@ jobs:
           pkg install -y ruby devel/ruby-gems
 
         run: |
+          sysctl -a | grep swap
           gem install bundler --no-document
           bundle install --quiet
           bundle exec rspec

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -46,7 +46,6 @@ jobs:
           pkg install -y ruby devel/ruby-gems
 
         run: |
-          sysctl -a | grep swap
           gem install bundler --no-document
           bundle install --quiet
           bundle exec rspec

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -15,7 +15,7 @@ jobs:
   test:
     strategy:
       matrix:
-        ruby-version: ['2.6', '2.7', '3.0', '3.1', '3.2', '3.3', 'jruby', 'truffleruby']
+        ruby-version: ['2.7', '3.0', '3.1', '3.2', '3.3', 'jruby', 'truffleruby']
         platform: [ubuntu-latest, macos-latest, windows-latest]
         exclude:
           - ruby-version: truffleruby
@@ -33,3 +33,19 @@ jobs:
         bundler-cache: true
     - name: Run tests
       run: bundle exec rake
+  freebsd:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Test in FreeBSD
+      id: test
+      uses: vmactions/freebsd-vm@v1
+      with:
+        usesh: true
+        prepare: |
+          pkg install -y ruby devel/ruby-gems
+
+        run: |
+          gem install bundler --no-document
+          bundle install --quiet
+          bundle exec rspec

--- a/lib/sys/bsd/memory.rb
+++ b/lib/sys/bsd/memory.rb
@@ -26,7 +26,13 @@ module Sys
       hash[:free] = get_by_name('vm.stats.vm.v_free_count') * page_size
       hash[:inactive] = get_by_name('vm.stats.vm.v_inactive_count') * page_size
       hash[:wire] = get_by_name('vm.stats.vm.v_wire_count') * page_size
-      hash[:swap_size] = get_by_name('vm.swap_size')
+
+      if RbConfig::CONFIG['host_os'] =~ /dragonfly/i
+        hash[:swap_size] = get_by_name('vm.swap_size')
+      else
+        hash[:swap_size] = get_by_name('vm.swap_total')
+      end
+
       hash[:swap_free] = get_by_name('vm.swap_free')
 
       hash

--- a/lib/sys/bsd/memory.rb
+++ b/lib/sys/bsd/memory.rb
@@ -85,7 +85,7 @@ module Sys
         size.write_int(optr.size)
 
         if sysctlbyname(mib, optr, size, nil, 0) < 0
-          raise SystemCallError.new('sysctlbyname', FFI.errno)
+          raise SystemCallError.new("sysctlbyname: #{mib}", FFI.errno)
         end
 
         value = optr.read_uint64

--- a/lib/sys/bsd/memory.rb
+++ b/lib/sys/bsd/memory.rb
@@ -32,6 +32,7 @@ module Sys
         hash[:swap_free] = get_by_name('vm.swap_free')
       else
         hash[:swap_size] = get_by_name('vm.swap_total')
+        hash[:swap_free] = hash[:swap_size] - get_by_name('vm.swap_reserved') # Best guess
       end
 
       hash

--- a/lib/sys/bsd/memory.rb
+++ b/lib/sys/bsd/memory.rb
@@ -29,11 +29,10 @@ module Sys
 
       if RbConfig::CONFIG['host_os'] =~ /dragonfly/i
         hash[:swap_size] = get_by_name('vm.swap_size')
+        hash[:swap_free] = get_by_name('vm.swap_free')
       else
         hash[:swap_size] = get_by_name('vm.swap_total')
       end
-
-      hash[:swap_free] = get_by_name('vm.swap_free')
 
       hash
     end


### PR DESCRIPTION
...and remove 2.6.

Update: This ended being a little more work, because the DragonflyBSD mibs for swap weren't valid on FreeBSD, so I've had to guess a bit as to what they should be.